### PR TITLE
Add Foundry VTT v14 compatibility

### DIFF
--- a/loot-generator.js
+++ b/loot-generator.js
@@ -2057,24 +2057,31 @@ Hooks.on("renderTokenConfig", (app, html, data) => {
     });
 });
 
-Hooks.on('renderDialog', async (app, html, data) => {
+async function rlgOnRenderDialog(app, html, data) {
   if (!game.user.isGM) return;
+  const $html = $(html);
+  const rootEl = $html[0];
   const title = app.title;
   const expectedTitles = [
     game.i18n.localize("RLG.ManageLootSources.Title"),
     game.i18n.format("RLG.CompendiumSelection.TitleFor", { creatureType: /.*/ }),
     game.i18n.format("RLG.TokenLootSettings.TitleFor", { name: /.*/ })
   ];
-  const isTargetDialog = expectedTitles.some(expected => 
+  const isTargetDialog = expectedTitles.some(expected =>
     typeof expected === 'string' ? title === expected : title.match(expected)
   );
   if (isTargetDialog) {
     rlgDebug(`Decorating dialog: ${title}`);
-    rlgDebug(`Dialog HTML (first 200 chars): ${html[0].outerHTML.substring(0, 200)}...`);
-    await rlgDecorateSourceDialog(app, html);
-    const disabledLabels = html.find('label.rlg-source--disabled');
+    rlgDebug(`Dialog HTML (first 200 chars): ${(rootEl?.outerHTML ?? '').substring(0, 200)}...`);
+    await rlgDecorateSourceDialog(app, $html);
+    const disabledLabels = $html.find('label.rlg-source--disabled');
     rlgDebug(`Found ${disabledLabels.length} disabled labels in ${title}`);
   } else {
     rlgDebug(`Skipping dialog: ${title} (not a target dialog)`);
   }
-});
+}
+
+// Register for both the V1 jQuery hook (`renderDialog`) and the v13+ HTMLElement hook
+// (`renderDialogV2`/`renderDialogHTML`) so the decorator keeps working across Foundry versions.
+Hooks.on('renderDialog', rlgOnRenderDialog);
+Hooks.on('renderDialogV2', rlgOnRenderDialog);

--- a/module.json
+++ b/module.json
@@ -9,7 +9,8 @@
   "download": "https://github.com/mfozz/random-loot-generator/releases/download/2.1.1/module.zip",
   "compatibility": {
     "minimum": "13",
-    "verified": "13"
+    "verified": "14",
+    "maximum": "14"
   },
   "languages": [
     {


### PR DESCRIPTION
## Summary
Minimal patch to restore Random Loot Generator compatibility with Foundry VTT v14.

## Changes
- `module.json`: bump `compatibility.verified` to `14` and add explicit `maximum: "14"` (minimum unchanged at `13`)
- `loot-generator.js`: harden the `renderDialog` decorator:
  - coerce `html` through `$(html)` so the decorator tolerates the HTMLElement variant Foundry v13/v14 pass to some render hooks
  - also subscribe to `renderDialogV2` so the source-count decoration keeps firing when dialogs surface through the v2 path

## Notes
- The module's `Dialog` and `FormApplication` usages still work on v14 with deprecation warnings — they are not rewritten here to keep the diff small and the behavior unchanged
- Tested against Foundry v14.359 with dnd5e 5.3.0: module loads, settings panel renders, token-config loot section injects, `getSceneControlButtons` button appears, auto-loot on `createToken` still fires
- Known residual v14 deprecation warnings (cosmetic, will need addressing by v15):
  - `Dialog` / `FormApplication` → migrate to `foundry.applications.api.DialogV2` / `ApplicationV2`
  - `renderDialog` (jQuery) → `renderDialogV2` / `renderDialogHTML`

## Test plan
- [x] Module loads on Foundry v14.359 without errors attributable to RLG
- [x] Settings panel renders with RLG sections and the "Manage Loot Sources" button
- [x] Token config shows the custom-loot fieldset; checkbox persists to actor flags
- [x] Generate-loot scene control button triggers loot generation on selected tokens
- [ ] Full functional pass across every dialog/form variant — maintainer's review advised